### PR TITLE
dom0/domd/domu: Add python2 meta-layer

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/doc/bblayers.conf.dom0-image-minimal-initramfs
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/doc/bblayers.conf.dom0-image-minimal-initramfs
@@ -15,4 +15,5 @@ BBLAYERS ?= " \
   ${TOPDIR}/../meta-openembedded/meta-python \
   ${TOPDIR}/../meta-openembedded/meta-filesystems \
   ${TOPDIR}/../meta-virtualization \
+  ${TOPDIR}/../meta-python2 \
 "

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/doc/bblayers.conf.rcar-domd-image-weston
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/doc/bblayers.conf.rcar-domd-image-weston
@@ -18,4 +18,5 @@ BBLAYERS ?= " \
   ${TOPDIR}/../meta-selinux \
   ${TOPDIR}/../meta-virtualization \
   ${TOPDIR}/../meta-clang \
+  ${TOPDIR}/../meta-python2 \
   "

--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/doc/bblayers.conf.rcar-domu-image-weston
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/doc/bblayers.conf.rcar-domu-image-weston
@@ -15,4 +15,5 @@ BBLAYERS ?= " \
   ${TOPDIR}/../meta-openembedded/meta-networking \
   ${TOPDIR}/../meta-openembedded/meta-python \
   ${TOPDIR}/../meta-clang \
+  ${TOPDIR}/../meta-python2 \
   "


### PR DESCRIPTION
Dunfell no longer supports python2.

Meta-layer is added in bbappend to fulfill python2 runtime dependency
in gles-user-module.

Signed-off-by: Valerii Chubar <valerii_chubar@epam.com>