### PR TITLE
dom0/domd: Add devd dependency in xen-tools

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/xen/xen-tools_git.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/xen/xen-tools_git.bbappend
@@ -2,3 +2,5 @@
 # Following inc file defines XEN version for the product and its SRC_URI
 ################################################################################
 require xen-version.inc
+
+RDEPENDS_${PN} = "${PN}-devd"

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/xen/xen-tools_git.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/xen/xen-tools_git.bbappend
@@ -2,3 +2,5 @@
 # Following inc file defines XEN version for the product and its SRC_URI
 ################################################################################
 require xen-version.inc
+
+RDEPENDS_${PN} = "${PN}-devd"


### PR DESCRIPTION
xen-tools-xencommons package fails to execute its post-install script
on rootfs, because there is a dependency on the xendriverdomain
Systemd service.

Add runtime dependency xen-tools-devd which provides
xendriverdomain.service

Signed-off-by: Valerii Chubar <valerii_chubar@epam.com>