### PR TITLE
domd/domu:gstreamer: Add dependency libgbm and wayland-kms

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_%.bbappend
@@ -1,0 +1,4 @@
+DEPENDS += " \
+    libgbm \
+    wayland-kms \
+"

--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_%.bbappend
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_%.bbappend
@@ -1,0 +1,4 @@
+DEPENDS += " \
+    libgbm \
+    wayland-kms \
+"


### PR DESCRIPTION
At linking stage libIMGegl.so requires libwayland-kms.so.0
and libgbm.so.1 library, but those are not found.

Add build time dependency wayland-kms and libgbm to fix build.

Signed-off-by: Valerii Chubar <valerii_chubar@epam.com>