### PR TITLE
domd: Install Xen explicitly

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-core/packagegroups/packagegroup-xt-core-xen.bb
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-core/packagegroups/packagegroup-xt-core-xen.bb
@@ -5,5 +5,6 @@ LICENSE = "MIT"
 inherit packagegroup
 
 RDEPENDS_packagegroup-xt-core-xen = "\
+    xen \
     xen-tools \
 "


### PR DESCRIPTION
Xen-tools do not contain Xen itself, but all user-space required
components. Make sure Xen installed for any build.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
Signed-off-by: Valerii Chubar <valerii_chubar@epam.com>