### PR TITLE
domd/domu:linux-renesas: Fix warning with duplicate defconfig

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -7,6 +7,8 @@ RENESAS_BSP_URL = "git://github.com/otyshchenko1/linux.git"
 BRANCH = "v5.4.72/rcar-4.1.0.rc2-xt0.1"
 SRCREV = "${AUTOREV}"
 LINUX_VERSION = "5.4.72"
+
+KBUILD_DEFCONFIG_rcar = ""
 SRC_URI_append = " \
     file://defconfig \
 "

--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -7,6 +7,8 @@ RENESAS_BSP_URL = "git://github.com/otyshchenko1/linux.git"
 BRANCH = "v5.4.72/rcar-4.1.0.rc2-xt0.1"
 SRCREV = "${AUTOREV}"
 LINUX_VERSION = "5.4.72"
+
+KBUILD_DEFCONFIG_rcar = ""
 SRC_URI_append = " \
     file://defconfig \
 "


### PR DESCRIPTION
In the recipe meta-renesas.bb KBUILD_DEFCONFIG variable is set to
defconfig, and local bbappend SRC_URI is overridden with the same
value.

Reset value KBUILD_DEFCONFIG to explicitly take defconfig from SRC_URI.
Fix the warning:
WARNING: defconfig was supplied both via KBUILD_DEFCONFIG and SRC_URI.

Signed-off-by: Valerii Chubar <valerii_chubar@epam.com>